### PR TITLE
Let OS decide a free port in unit test

### DIFF
--- a/Zhaobang.FtpServer.Tests/FtpServerTests.cs
+++ b/Zhaobang.FtpServer.Tests/FtpServerTests.cs
@@ -95,32 +95,14 @@ namespace Zhaobang.FtpServer.Tests
 
         private IPEndPoint StartFtpServer()
         {
-            Random random = new();
-            int attempt = 0;
-            while (true)
-            {
-                IPEndPoint serverEndPoint = new(IPAddress.IPv6Loopback, random.Next(1024, IPEndPoint.MaxPort + 1));
-                this.server = new(
-                    serverEndPoint,
-                    new MockFileProviderFactory(),
-                    new LocalDataConnectionFactory(),
-                    new AnonymousAuthenticator());
-                try
-                {
-                    this.serverRunTask = this.server.RunAsync(this.serverRunCts.Token);
-                }
-                catch (SocketException ex)
-                {
-                    if (ex.SocketErrorCode == SocketError.AddressAlreadyInUse && (attempt++ < 10))
-                    {
-                        continue;
-                    }
-
-                    throw;
-                }
-
-                return serverEndPoint;
-            }
+            IPEndPoint serverEndPoint = new(IPAddress.IPv6Loopback, 0);
+            this.server = new(
+                serverEndPoint,
+                new MockFileProviderFactory(),
+                new LocalDataConnectionFactory(),
+                new AnonymousAuthenticator());
+            this.serverRunTask = this.server.RunAsync(this.serverRunCts.Token);
+            return this.server.EndPoint;
         }
 
         private class MockFileProviderFactory : IFileProviderFactory

--- a/Zhaobang.FtpServer/Assembly.cs
+++ b/Zhaobang.FtpServer/Assembly.cs
@@ -1,0 +1,7 @@
+// <copyright file="Assembly.cs" company="Zhaoquan Huang">
+// Copyright (c) Zhaoquan Huang. All rights reserved
+// </copyright>
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Zhaobang.FtpServer.Tests")]

--- a/Zhaobang.FtpServer/FtpServer.cs
+++ b/Zhaobang.FtpServer/FtpServer.cs
@@ -29,7 +29,6 @@ namespace Zhaobang.FtpServer
         private readonly IControlConnectionSslFactory controlConnectionSslFactory;
         private readonly FtpTracer tracer = new FtpTracer();
 
-        private IPEndPoint endPoint;
         private TcpListener tcpListener;
 
         /// <summary>
@@ -77,7 +76,6 @@ namespace Zhaobang.FtpServer
             IAuthenticator authenticator,
             IControlConnectionSslFactory controlConnectionSslFactory)
         {
-            this.endPoint = endPoint;
             tcpListener = new TcpListener(endPoint);
 
             this.fileProviderFactory = fileProviderFactory;
@@ -113,6 +111,11 @@ namespace Zhaobang.FtpServer
         /// Gets the factory to upgrade control connection to an encrypted one. May be null.
         /// </summary>
         internal IControlConnectionSslFactory ControlConnectionSslFactory => controlConnectionSslFactory;
+
+        /// <summary>
+        /// Gets the local end point the server is listening on.
+        /// </summary>
+        internal IPEndPoint EndPoint => tcpListener.LocalEndpoint as IPEndPoint;
 
         /// <summary>
         /// Start the FTP server.


### PR DESCRIPTION
When running FtpServerTests, let OS decide a free port instead of trying randomly