### PR TITLE
Fix all-whitespace response of LIST command

### DIFF
--- a/Zhaobang.FtpServer.Tests/Connections/ControlConnectionTests.cs
+++ b/Zhaobang.FtpServer.Tests/Connections/ControlConnectionTests.cs
@@ -107,7 +107,7 @@ namespace Zhaobang.FtpServer.Tests.Connections
             Assert.IsNotNull(epsvResponse);
 
             ReadOnlySpan<byte> epsvAddress = GetAddressFromEpsv(epsvResponse);
-            var epsvPortNum = GetPortFromEpsvAddress(epsvAddress);
+            int epsvPortNum = GetPortFromEpsvAddress(epsvAddress);
             using TcpClient dataClient = new(this.serverEndPoint.AddressFamily);
             await dataClient.ConnectAsync(this.serverEndPoint.Address, epsvPortNum, this.testContext.CancellationToken);
 

--- a/Zhaobang.FtpServer/Connections/ControlConnection.cs
+++ b/Zhaobang.FtpServer/Connections/ControlConnection.cs
@@ -177,6 +177,12 @@ namespace Zhaobang.FtpServer.Connections
                 while (true)
                 {
                     var command = await ReadLineAsync();
+                    if (command == null)
+                    {
+                        // Reaches end of stream
+                        break;
+                    }
+
                     try
                     {
                         await ProcessCommandAsync(command);
@@ -460,7 +466,7 @@ namespace Zhaobang.FtpServer.Connections
             try
             {
                 var listing = await fileProvider.GetListingAsync(parameter);
-                await writer.WriteLineAsync();
+                await writer.WriteLineAsync($"Total {listing.Count()}");
                 foreach (var item in listing)
                 {
                     if (listFormat == ListFormat.Unix)
@@ -838,7 +844,7 @@ namespace Zhaobang.FtpServer.Connections
                 var byteCount = await stream.ReadAsync(readByteBuffer, readOffset, readByteBuffer.Length - readOffset);
                 if (byteCount == 0)
                 {
-                    throw new EndOfStreamException();
+                    return null;
                 }
                 for (int i = readOffset; i < readOffset + byteCount; i++)
                 {


### PR DESCRIPTION
Previously LIST command produces a result with only "\r\n" when there is no file in the selected directory. This causes Windows File Explorer to throw an error.